### PR TITLE
Fix build

### DIFF
--- a/choosatron-core-firmware.mk
+++ b/choosatron-core-firmware.mk
@@ -4,7 +4,7 @@
 # Add include paths.
 INCLUDE_DIRS += applications/choosatron-core-firmware/inc
 INCLUDE_DIRS += applications/choosatron-core-firmware/lib/elapsed_time/inc
-INCLUDE_DIRS += applications/choosatron-core-firmware/lib/memory_free/inc
+INCLUDE_DIRS += applications/choosatron-core-firmware/lib/Memory_Free/inc
 INCLUDE_DIRS += applications/choosatron-core-firmware/lib/sd/inc
 INCLUDE_DIRS += applications/choosatron-core-firmware/lib/flashee/inc
 INCLUDE_DIRS += applications/choosatron-core-firmware/lib/ymodem/inc

--- a/lib/sd/inc/Sd2Card_config.h
+++ b/lib/sd/inc/Sd2Card_config.h
@@ -1,7 +1,7 @@
 #ifndef __SD2CARD_CONFIG_H__
 #define __SD2CARD_CONFIG_H__
 
-#include <Application.h>
+#include <application.h>
 //#include "spark_wiring.h"
 
 #define SD_SPI_NUMBER	2					/* Specify HardwareSPI number */

--- a/lib/sd/inc/SdFat.h
+++ b/lib/sd/inc/SdFat.h
@@ -23,7 +23,7 @@
  * \file
  * SdFile and SdVolume classes
  */
-#include <Application.h>
+#include <application.h>
 #include "SdFatUtil.h"
 #include "Sd2Card.h"
 #include "FatStructs.h"

--- a/lib/sd/inc/SdFatUtil.h
+++ b/lib/sd/inc/SdFatUtil.h
@@ -23,7 +23,7 @@
  * \file
  * Useful utility functions.
  */
-#include <Application.h>
+#include <application.h>
 #include <Sd2Card.h>
 //#include <string.h>
 /*

--- a/lib/sd/inc/SdInfo.h
+++ b/lib/sd/inc/SdInfo.h
@@ -20,7 +20,7 @@
 #ifndef SdInfo_h
 #define SdInfo_h
 
-#include <Application.h>
+#include <application.h>
 //#include <stdint.h>
 
 // Based on the document:

--- a/lib/sd/src/Sd2Card.cpp
+++ b/lib/sd/src/Sd2Card.cpp
@@ -18,7 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include <Application.h>
+#include <application.h>
 #include "Sd2Card.h"
 
 //#include "spark_wiring_spi.h"

--- a/lib/sd/src/SdFile.cpp
+++ b/lib/sd/src/SdFile.cpp
@@ -18,7 +18,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include <Application.h>
+#include <application.h>
 #include "SdFat.h"
 #include "SdFatUtil.h"
 

--- a/lib/sd/src/SdVolume.cpp
+++ b/lib/sd/src/SdVolume.cpp
@@ -17,7 +17,7 @@
  * along with the Arduino SdFat Library.  If not, see
  * <http://www.gnu.org/licenses/>.
  */
-#include <Application.h>
+#include <application.h>
 #include "SdFat.h"
 
 //#include "spark_wiring_usbserial.h"


### PR DESCRIPTION
Hello,
I tried to build the project from scratch following the README instructions and I had to fix 2 issues.

```
arm-none-eabi-gcc -DSTM32_DEVICE -DSTM32F10X_MD -DPLATFORM_ID=0 -DSPARK_PLATFORM -DSTM32_DEVICE -DSTM32F10X_MD -DPLATFORM_ID=0 -DINCLUDE_PLATFORM=1 -DSPARK_PLATFORM_NET=CC3000 -DPRODUCT_ID=65535 -DPRODUCT_FIRMWARE_VERSION=65535 -DUSE_STDPERIPH_DRIVER -DDFU_BUILD_ENABLE -DRELEASE_BUILD -I./inc -Iapplications/choosatron-core-firmware/inc -Iapplications/choosatron-core-firmware/lib/elapsed_time/inc -Iapplications/choosatron-core-firmware/lib/memory_free/inc -Iapplications/choosatron-core-firmware/lib/sd/inc -Iapplications/choosatron-core-firmware/lib/flashee/inc -Iapplications/choosatron-core-firmware/lib/ymodem/inc -I./libraries -I../wiring/inc -I../services/inc -I../communication/src -I../communication/lib/tropicssl/include -I../hal/inc -I../hal/shared -I../hal/src/core-v1 -I../platform/MCU/STM32F1xx/STM32_StdPeriph_Driver/inc -I../platform/MCU/STM32F1xx/STM32_USB_Device_Driver/inc -I../platform/MCU/STM32F1xx/SPARK_Firmware_Driver/inc -I../platform/MCU/STM32F1xx/CMSIS/Include -I../platform/MCU/STM32F1xx/CMSIS/Device/ST/Include -I../platform/NET/CC3000/CC3000_Host_Driver -I../bootloader/src/core-v2 -I. -MD -MP -MF ../build/target/main/platform-0/./applications/choosatron-core-firmware/src/cdam_hardware_manager.o.d -ffunction-sections -Wall -Werror -Wno-switch -fmessage-length=0 -fno-strict-aliasing -DSPARK=1 -g3 -gdwarf-2 -Os -mcpu=cortex-m3 -mthumb  -std=gnu++11 -fno-exceptions -fno-rtti -c -o ../build/target/main/platform-0/./applications/choosatron-core-firmware/src/cdam_hardware_manager.o applications/choosatron-core-firmware/src/cdam_hardware_manager.cpp
In file included from applications/choosatron-core-firmware/inc/cdam_data_manager.h:32:0,
                 from applications/choosatron-core-firmware/inc/cdam_manager.h:26,
                 from applications/choosatron-core-firmware/src/cdam_hardware_manager.cpp:3:
applications/choosatron-core-firmware/lib/sd/inc/SdFat.h:26:25: fatal error: Application.h: No such file or directory
 #include <Application.h>
                         ^
compilation terminated.
../build/module.mk:177: recipe for target '../build/target/main/platform-0/./applications/choosatron-core-firmware/src/cdam_hardware_manager.o' failed
make: *** [../build/target/main/platform-0/./applications/choosatron-core-firmware/src/cdam_hardware_manager.o] Error 1
```

All the files in the `sd` library  are including `Application.h` but I could only find a file called `application.h` (lower case). I changed the `#include` directives which fixed the issue and I got the 2nd error.

```
arm-none-eabi-gcc -DSTM32_DEVICE -DSTM32F10X_MD -DPLATFORM_ID=0 -DSPARK_PLATFORM -DSTM32_DEVICE -DSTM32F10X_MD -DPLATFORM_ID=0 -DINCLUDE_PLATFORM=1 -DSPARK_PLATFORM_NET=CC3000 -DPRODUCT_ID=65535 -DPRODUCT_FIRMWARE_VERSION=65535 -DUSE_STDPERIPH_DRIVER -DDFU_BUILD_ENABLE -DRELEASE_BUILD -I./inc -Iapplications/choosatron-core-firmware/inc -Iapplications/choosatron-core-firmware/lib/elapsed_time/inc -Iapplications/choosatron-core-firmware/lib/memory_free/inc -Iapplications/choosatron-core-firmware/lib/sd/inc -Iapplications/choosatron-core-firmware/lib/flashee/inc -Iapplications/choosatron-core-firmware/lib/ymodem/inc -I./libraries -I../wiring/inc -I../services/inc -I../communication/src -I../communication/lib/tropicssl/include -I../hal/inc -I../hal/shared -I../hal/src/core-v1 -I../platform/MCU/STM32F1xx/STM32_StdPeriph_Driver/inc -I../platform/MCU/STM32F1xx/STM32_USB_Device_Driver/inc -I../platform/MCU/STM32F1xx/SPARK_Firmware_Driver/inc -I../platform/MCU/STM32F1xx/CMSIS/Include -I../platform/MCU/STM32F1xx/CMSIS/Device/ST/Include -I../platform/NET/CC3000/CC3000_Host_Driver -I../bootloader/src/core-v2 -I. -MD -MP -MF ../build/target/main/platform-0/./applications/choosatron-core-firmware/lib/Memory_Free/src/memory_free.o.d -ffunction-sections -Wall -Werror -Wno-switch -fmessage-length=0 -fno-strict-aliasing -DSPARK=1 -g3 -gdwarf-2 -Os -mcpu=cortex-m3 -mthumb  -std=gnu++11 -fno-exceptions -fno-rtti -c -o ../build/target/main/platform-0/./applications/choosatron-core-firmware/lib/Memory_Free/src/memory_free.o applications/choosatron-core-firmware/lib/Memory_Free/src/memory_free.cpp
applications/choosatron-core-firmware/lib/Memory_Free/src/memory_free.cpp:1:25: fatal error: memory_free.h: No such file or directory
 #include "memory_free.h"
                         ^
compilation terminated.
../build/module.mk:177: recipe for target '../build/target/main/platform-0/./applications/choosatron-core-firmware/lib/Memory_Free/src/memory_free.o' failed
make: *** [../build/target/main/platform-0/./applications/choosatron-core-firmware/lib/Memory_Free/src/memory_free.o] Error 1
```

`memory_free.h` cannot be found. The parameters say `-Iapplications/choosatron-core-firmware/lib/memory_free/inc` but the folder is named `Memory_Free`. I fixed it in the `.mk` file.

And now I can build it! :-)
